### PR TITLE
fix: implement filesystem-based secret key listing

### DIFF
--- a/secrets/interfaces.go
+++ b/secrets/interfaces.go
@@ -11,6 +11,7 @@ import (
 type FileReader interface {
 	ReadFile(path string) ([]byte, error)
 	Stat(name string) (fs.FileInfo, error)
+	ReadDir(dirname string) ([]fs.DirEntry, error)
 }
 
 // FileWatcher defines the interface for watching file changes
@@ -36,6 +37,10 @@ func (r *osReadFile) ReadFile(path string) ([]byte, error) {
 
 func (r *osReadFile) Stat(name string) (fs.FileInfo, error) {
 	return os.Stat(name)
+}
+
+func (r *osReadFile) ReadDir(dirname string) ([]fs.DirEntry, error) {
+	return os.ReadDir(dirname)
 }
 
 // fsNotifyWatcherFactory implements FileWatcherFactory using fsnotify


### PR DESCRIPTION
- Fix ListSecretKeys() to scan filesystem instead of returning cached secrets only
- Add ReadDir method to FileReader interface for directory scanning
- Update SecretLoader interface to return error from ListSecretKeys()
- Implement proper filtering: exclude hidden files and directories
- Add comprehensive test coverage for all scenarios:
  - Empty directories
  - Regular files only
  - Hidden files filtering
  - Mixed file types (files, hidden files, subdirectories)
  - Directory read errors
  - Closed loader error handling
- Update mock filesystem to support directory operations
- Ensure thread safety with race condition testing

Breaking change: ListSecretKeys() signature changed from []string to ([]string, error)

Resolves incorrect behavior where only loaded secrets were returned instead of all available secrets in the configured directory.